### PR TITLE
Add in app-config.js file so you can overwrite portal api calls

### DIFF
--- a/my-app-seed-war/src/main/webapp/js/app-config.js
+++ b/my-app-seed-war/src/main/webapp/js/app-config.js
@@ -1,0 +1,8 @@
+
+(function() {
+angular.module('app-config', [])
+.constant('SERVICE_LOC', {'sessionInfo' : 'json/sessionsample.json',
+                             'sidebarInfo' : 'samples/sidebar.json'
+                            });
+
+})();

--- a/my-app-seed-war/src/main/webapp/json/sessionsample.json
+++ b/my-app-seed-war/src/main/webapp/json/sessionsample.json
@@ -1,0 +1,9 @@
+{
+  "person": {
+   "userName": "admin",
+   "sessionKey": "someRandomKey",
+   "serverName": "local",
+   "displayName": "Aaron Administrator",
+   "version": "4.1.1.18-SNAPSHOT"
+  }
+}


### PR DESCRIPTION
We introduced some constants in the file `js/app-config.js` in the [frame](https://github.com/UW-Madison-DoIT/angularjs-portal/blob/master/angularjs-portal-frame/src/main/webapp/js/app-config.js). In the default frame code you will see these URLs point at `/portal`. However, if your seed app isn't running in the portal container you will need to redirect these. This gives you that flexibility. 
